### PR TITLE
feat: add `enabled` option to conditionally disable the module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ node_modules
 # Generated dirs
 dist
 
+# Linter cache
+.eslintcache
+
 # Nuxt
 .nuxt
 .output

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ export default defineNuxtConfig({
   modules: ["nuxt-yandex-metrika"],
   yandexMetrika: {
     id: 'XXXXXX',
+    // enabled: process.env.NODE_ENV === "production",
     // debug: process.env.NODE_ENV !== "production",
     // delay: 0,
     // cdn: false,
@@ -56,6 +57,7 @@ export default defineNuxtConfig({
 | Name           | Default value | Type                             | Description                                                                                             |
 |----------------|---------------|----------------------------------|---------------------------------------------------------------------------------------------------------|
 | `id`           | —             | `string`                         | **Required.** Yandex Metrika counter ID                                                                 |
+| `enabled`      | `true`        | `boolean`                        | Conditionally enable/disable the module. When `false`, no script is injected and the composable becomes a no-op. Useful for staging environments |
 | `debug`        | `false`       | `boolean`                        | Enables debug mode. Useful during development. When enabled, additional logs are printed to the console |
 | `delay`        | `0`           | `number`                         | Delay (in milliseconds) before initializing Yandex Metrika                                              |
 | `cdn`          | `false`       | `boolean`                        | Load Metrika script from Yandex CDN instead of the default source                                       |

--- a/src/module.ts
+++ b/src/module.ts
@@ -17,6 +17,7 @@ export default defineNuxtModule<YandexMetrikaModuleOptions>({
 	},
 	defaults: {
 		id: 'xxx',
+		enabled: true,
 		debug: import.meta.env.NODE_ENV !== 'production',
 		delay: 0,
 		cdn: false,
@@ -40,6 +41,7 @@ export default defineNuxtModule<YandexMetrikaModuleOptions>({
 			options,
 			{
 				id: 'xxx',
+				enabled: true,
 				debug: import.meta.env.NODE_ENV !== 'production',
 				delay: 0,
 				cdn: false,
@@ -60,10 +62,12 @@ export default defineNuxtModule<YandexMetrikaModuleOptions>({
 			}
 		);
 		const resolver = createResolver(import.meta.url);
-		addPlugin({
-			mode: 'all',
-			src: resolver.resolve('./runtime/plugin')
-		});
+		if (options.enabled !== false) {
+			addPlugin({
+				mode: 'all',
+				src: resolver.resolve('./runtime/plugin')
+			});
+		}
 
 		addImports({
 			name: 'useYandexMetrika',

--- a/src/runtime/composable.ts
+++ b/src/runtime/composable.ts
@@ -12,33 +12,36 @@ function _useYandexMetrikaScript<T extends YandexMetrikaApi>() {
 	return useRegistryScript<T, typeof YandexMetrikaSchemeOptions>(
 		'yandex-metrika',
 		(config) => {
-			const { id, cdn, delay, debug, verification, options = {}, position = 'head' } = config;
-			const api = metrika(id, debug);
-			useHead({
-				script: [
-					{
-						tagPosition: position,
-						innerHTML:
-							'window.ym=window.ym||function(){(window.ym.a=window.ym.a||[]).push(arguments)};window.ym.l=(new Date).getTime();'
-					}
-				]
-			});
+			const { id, cdn, delay, debug, enabled = true, verification, options = {}, position = 'head' } = config;
+			const api = metrika(id, debug, enabled);
 
-			if (verification) {
+			if (enabled) {
 				useHead({
-					meta: [{ name: 'yandex-verification', content: verification }]
-				});
-			}
-
-			if (!import.meta.dev) {
-				useHead({
-					noscript: [
+					script: [
 						{
-							innerHTML: `<div><img src="https://mc.yandex.ru/watch/${id}" style="position:absolute; left:-9999px;" alt=""></div>`,
-							tagPosition: position
+							tagPosition: position,
+							innerHTML:
+								'window.ym=window.ym||function(){(window.ym.a=window.ym.a||[]).push(arguments)};window.ym.l=(new Date).getTime();'
 						}
 					]
 				});
+
+				if (verification) {
+					useHead({
+						meta: [{ name: 'yandex-verification', content: verification }]
+					});
+				}
+
+				if (!import.meta.dev) {
+					useHead({
+						noscript: [
+							{
+								innerHTML: `<div><img src="https://mc.yandex.ru/watch/${id}" style="position:absolute; left:-9999px;" alt=""></div>`,
+								tagPosition: position
+							}
+						]
+					});
+				}
 			}
 
 			return {
@@ -50,13 +53,15 @@ function _useYandexMetrikaScript<T extends YandexMetrikaApi>() {
 					key: 'yandex-metrika',
 					bundle: false,
 					tagPosition: position,
-					trigger: delay ? useScriptTriggerIdleTimeout({ timeout: delay }) : undefined,
+					trigger: enabled ? (delay ? useScriptTriggerIdleTimeout({ timeout: delay }) : undefined) : 'manual',
 					use() {
 						return api;
 					}
 				},
 				async clientInit() {
-					api.init(options);
+					if (enabled) {
+						api.init(options);
+					}
 				}
 			};
 		},

--- a/src/runtime/scheme.ts
+++ b/src/runtime/scheme.ts
@@ -37,6 +37,7 @@ const options = object({
 
 export const YandexMetrikaSchemeOptions = object({
 	id: string(),
+	enabled: boolean(),
 	debug: boolean(),
 	delay: number(),
 	cdn: boolean(),

--- a/src/runtime/yandex-metrika/metrika.ts
+++ b/src/runtime/yandex-metrika/metrika.ts
@@ -6,10 +6,13 @@ import { Methods } from './types';
 
 export * from './types';
 
-export function metrika(id: string, debug: boolean = false): YandexMetrikaApi {
+export function metrika(id: string, debug: boolean = false, enabled: boolean = true): YandexMetrikaApi {
 	function call(type: ValueOf<typeof Methods>, ...args: unknown[]) {
 		if (debug) {
 			consola.info(`[yandex-metrika] ${type}`, ...args);
+		}
+		if (!enabled) {
+			return;
 		}
 		window.ym(id, type, ...args);
 	}


### PR DESCRIPTION
Adds an `enabled` option (default `true`) that, when set to `false`,
skips plugin registration, script injection (counter stub, tag.js,
noscript pixel and verification meta) and makes `useYandexMetrika`
a no-op. Useful for staging environments.

Closes #4

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WReLQNzvZ3K7VkKRvC3EkB